### PR TITLE
Escape Startup without Profiling Token

### DIFF
--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -51,7 +51,7 @@ class LaravelOpenTelemetryServiceProvider extends ServiceProvider
      */
     private function initOpenTelemetry(): ?Tracer
     {
-        if (!config('laravel_codecov_opentelemetry.enable')) {
+        if (!config('laravel_codecov_opentelemetry.enable') || !config('laravel_codecov_opentelemetry.profiling_token')) {
             return null;
         }
 


### PR DESCRIPTION
returns null from init if no token is set.