### PR TITLE
Add $retry param to `export`

### DIFF
--- a/src/Codecov/Exporter.php
+++ b/src/Codecov/Exporter.php
@@ -162,7 +162,10 @@ class Exporter implements Trace\Exporter
     {
         try {
             if (!$version) {
-                return null;
+                // If we do not get a falsy version, we set to "NO_VERSION"
+                // This is specifically different than "default" which is the value
+                // we use when a user doesn't specify the version at all.
+                $version = "NO_VERSION";
             }
 
             $env = config('laravel_codecov_opentelemetry.execution_environment');

--- a/src/Codecov/Exporter.php
+++ b/src/Codecov/Exporter.php
@@ -112,7 +112,7 @@ class Exporter implements Trace\Exporter
      *
      * @return int return code, defined on the Exporter interface
      */
-    public function export(iterable $spans): int
+    public function export(iterable $spans, bool $retry = true): int
     {
         if (!$this->running) {
             return Trace\Exporter::FAILED_NOT_RETRYABLE;
@@ -134,7 +134,8 @@ class Exporter implements Trace\Exporter
 
             $presignedURL = $this->getPresignedPut($this->authToken, $this->uploadsUrl, $version);
 
-            $response = $this->makeRequest(
+
+            $this->makeRequest(
                 'PUT',
                 $presignedURL,
                 ['content-type' => 'application/txt'],
@@ -142,9 +143,12 @@ class Exporter implements Trace\Exporter
             );
         } catch (NoCodeException $e) {
             // We did not have a code. so we have to create one and try again.
-            $version = $this->setProfilerVersion($this->authToken, config('laravel_codecov_opentelemetry.execution_environment'), $this->versionsUrl, $version);
-
-            return $this->export($spans);
+            // Prevents an infinite recursion scenario that can happen if `profiling/versions` consistently
+            // fails.
+            if ($retry) {
+                $version = $this->setProfilerVersion($this->authToken, config('laravel_codecov_opentelemetry.execution_environment'), $this->versionsUrl, $version);
+                return $this->export($spans, false);
+            }
         } catch (RequestExceptionInterface $e) {
             return Trace\Exporter::FAILED_NOT_RETRYABLE;
         } catch (NetworkExceptionInterface | ClientExceptionInterface $e) {

--- a/tests/Unit/ExporterTest.php
+++ b/tests/Unit/ExporterTest.php
@@ -56,16 +56,17 @@ it('will terminate successfully if there are no spans to export', function () {
     $this->assertEquals(Trace\Exporter::SUCCESS, $exporter->export([]));
 });
 
-it('will not set a profiler version without a profiling_id', function () {
+it('will set some version without a profiling_id', function () {
     config(['laravel_codecov_opentelemetry.profiling_id' => null]);
 
-    $exporter = new CodecovExporter(
-        config('laravel_codecov_opentelemetry.service_name'),
-        config('laravel_codecov_opentelemetry.codecov_host'),
-        config('laravel_codecov_opentelemetry.profiling_token')
-    );
 
-    $this->assertEquals(null, $exporter->setProfilerVersion('abc123', 'local', 'https://profilingurl', config('laravel_codecov_opentelemetry.profiling_id')));
+    $mock = Mockery::mock(CodecovExporter::class)->makePartial();
+
+    $mock->shouldReceive('makeRequest')
+        ->andReturn((object) ['external_id' => 1])
+    ;
+
+    $this->assertEquals($mock->setProfilerVersion('abc123', 'local', 'https://profilingurl', config('laravel_codecov_opentelemetry.profiling_id')), 1);
 });
 
 it('properly sets a profiler version', function () {


### PR DESCRIPTION
Adds a retry parameter that prevents infinite recursion in the event that the upstream api is somehow failing.