### PR TITLE
Remove NO_VERSION

### DIFF
--- a/src/Codecov/Exporter.php
+++ b/src/Codecov/Exporter.php
@@ -162,9 +162,9 @@ class Exporter implements Trace\Exporter
     {
         try {
             if (!$version) {
-                // If we do not get a falsy version, we set to "NO_VERSION"
-                // This is specifically different than "default" which is the value
-                // we use when a user doesn't specify the version at all.
+                // If we do not get a falsy version, set to
+                // "default" which is the value we use when
+                // a user doesn't specify the version at all.
                 $version = 'default';
             }
 

--- a/src/Codecov/Exporter.php
+++ b/src/Codecov/Exporter.php
@@ -165,7 +165,7 @@ class Exporter implements Trace\Exporter
                 // If we do not get a falsy version, we set to "NO_VERSION"
                 // This is specifically different than "default" which is the value
                 // we use when a user doesn't specify the version at all.
-                $version = "NO_VERSION";
+                $version = 'default';
             }
 
             $env = config('laravel_codecov_opentelemetry.execution_environment');


### PR DESCRIPTION
The use of NO_VERSION creates an issue because generating the presigned PUT expects either a defined version or "default". Therefore, when creating the version, we must also use "default" as our default version instead of `NO_VERSION`