### PR TITLE
Ensure Valid Coverage ID

### DIFF
--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -67,7 +67,9 @@ class Trace
                 $filter
             );
 
-            $coverage->start($request->route()->getName());
+            //if we cannot get the route name, just use the time as a unique identifier.
+            $name = $request->route() ? $request->route()->getName() : ''.time();
+            $coverage->start($name ?? ''. time());
         }
 
         $response = $next($request);


### PR DESCRIPTION
In some cases laravel's `Route::getName()` method can return null. In those cases we just supply the current time as the id of the pcov run.