### PR TITLE
Update Code with Environment

### DIFF
--- a/src/Codecov/Exporter.php
+++ b/src/Codecov/Exporter.php
@@ -170,6 +170,10 @@ class Exporter implements Trace\Exporter
 
             $env = config('laravel_codecov_opentelemetry.execution_environment');
 
+            // append a valid environment if it exists.
+            // This will allow the same version to be used across environments.
+            $code = $env ? $env . '-' . $version : $version;
+
             $response = $this->client->sendRequest(
                 'POST',
                 $versionsUrl,
@@ -181,7 +185,7 @@ class Exporter implements Trace\Exporter
                 [
                     'version_identifier' => $version,
                     'environment' => $env,
-                    'code' => $version,
+                    'code' => $code,
                 ]
             );
 

--- a/tests/Unit/ExporterTest.php
+++ b/tests/Unit/ExporterTest.php
@@ -78,6 +78,31 @@ it('will set some version without a profiling_id', function () {
     $this->assertEquals($exporter->setProfilerVersion('abc123', 'local', 'https://profilingurl', config('laravel_codecov_opentelemetry.profiling_id')), 1);
 });
 
+
+it('will set some version without an environment', function () {
+    config(['laravel_codecov_opentelemetry.profiling_id' => null]);
+    config(['laravel_codecov_opentelemetry.execution_environment' => null]);
+
+    $responseMock = Mockery::mock('Psr\Http\Message\ResponseInterface')->makePartial();
+    $responseMock->shouldReceive('getBody')
+                 ->andReturn(json_encode(['external_id' => 1]));
+
+    $mockClient = Mockery::mock(ApiClient::class)->makePartial();
+    $mockClient->shouldReceive('sendRequest')
+        ->andReturn($responseMock);
+
+    $exporter = new CodecovExporter(
+        config('laravel_codecov_opentelemetry.service_name'),
+        config('laravel_codecov_opentelemetry.codecov_host'),
+        config('laravel_codecov_opentelemetry.profiling_token'),
+        $mockClient
+    );
+
+
+    $this->assertEquals($exporter->setProfilerVersion('abc123', 'local', 'https://profilingurl', config('laravel_codecov_opentelemetry.profiling_id')), 1);
+});
+
+
 it('properly sets a profiler version', function () {
     $responseMock = Mockery::mock('Psr\Http\Message\ResponseInterface')->makePartial();
     $responseMock->shouldReceive('getBody')


### PR DESCRIPTION
Codecov will not allow uploads to the same version with different environments if those two environments use the same code parameter.

This change ensures that the env will be prepended to the code before it is sent such that you can have a version exist across multiple environments (e.g., testing and prod)