### PR TITLE
Fix Name Output

### DIFF
--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -84,6 +84,11 @@ class Trace
         $this->setSpanStatus($span, $response->status());
         $this->addConfiguredTags($span, $request, $response);
 
+        $uri = $request->route() ? $request->route()->uri() : null;
+        if($uri) {
+            $span->updateName($uri);
+        }
+
         $this->tracer->endActiveSpan();
 
         return $response;


### PR DESCRIPTION
`name` field on spans was previously defaulting to "http_get". This change fixes that such that the `name` field properly indicates the uri for better visibility into the route from which the span originated.