### PR TITLE
Fix Broken Profile ID on Exporter

### DIFF
--- a/src/Codecov/Exporter.php
+++ b/src/Codecov/Exporter.php
@@ -254,6 +254,10 @@ class Exporter implements Trace\Exporter
         try {
             if (!$externalId) {
                 $externalId = 'default';
+            } else {
+                //code is id + env
+                $env = config('laravel_codecov_opentelemetry.execution_environment');
+                $externalId = $env ? $env . '-' . $externalId : $externalId;
             }
 
             $response = $this->client->sendRequest(


### PR DESCRIPTION
Fixes an issue on the exporter that could lead to mismatches between the version set by the library and the version referenced when generating presigned PUTs.

This issue is due to a fix in #26 that properly updated how the code was created, but did not carry that change into future references of the created code.